### PR TITLE
fix: bump pytest constraint to <10, add CIM-XML serializer tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ lxml-stubs = ">=0.4,<0.6"
 pip-tools = "^7.4.1"
 
 [tool.poetry.group.tests.dependencies]
-pytest = ">=7.1.3,<9.0.0"
+pytest = ">=7.1.3,<10.0.0"
 pytest-cov = ">=4,<7"
 coverage = {version = "^7.0.1", extras = ["toml"]}
 types-setuptools = ">=68.0.0.3,<72.0.0.0"

--- a/rdflib/plugins/serializers/cimxml.py
+++ b/rdflib/plugins/serializers/cimxml.py
@@ -31,7 +31,6 @@ def fix(val: str) -> str:
     else:
         return val
 
-# ... existing imports ...
 
 class CIMXMLSerializer(Serializer):
     def __init__(self, store: Graph):

--- a/test/test_serializers/test_serializer_cimxml.py
+++ b/test/test_serializers/test_serializer_cimxml.py
@@ -1,0 +1,108 @@
+"""Tests for the CIM-XML serializer (rdflib.plugins.serializers.cimxml).
+
+Input:  rdflib.Graph populated with CIM triples
+Output: Verified XML bytes from CIMXMLSerializer
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from io import BytesIO
+
+import pytest
+from rdflib import Graph, Namespace, URIRef
+from rdflib.namespace import RDF
+
+from rdflib.plugins.serializers.cimxml import CIMXMLSerializer
+
+CIM = Namespace("http://iec.ch/TC57/CIM100#")
+PROFILE_URI = "http://iec.ch/TC57/ns/CIM/CoreEquipment-EU/3.0"
+
+
+def _make_graph() -> tuple[Graph, URIRef]:
+    g = Graph()
+    g.bind("cim", CIM)
+    subj = URIRef("urn:uuid:test-acline-1")
+    g.add((subj, RDF.type, CIM.ACLineSegment))
+    return g, subj
+
+
+def _serialize(graph: Graph, **kwargs: object) -> bytes:
+    serializer = CIMXMLSerializer(graph)
+    stream = BytesIO()
+    serializer.serialize(stream, profile_uri=PROFILE_URI, **kwargs)
+    stream.seek(0)
+    return stream.read()
+
+
+def test_raises_without_profile_uri() -> None:
+    g, _ = _make_graph()
+    serializer = CIMXMLSerializer(g)
+    with pytest.raises(ValueError, match="profile_uri"):
+        serializer.serialize(BytesIO())
+
+
+def test_raises_with_zero_max_depth() -> None:
+    g, _ = _make_graph()
+    serializer = CIMXMLSerializer(g)
+    with pytest.raises(AssertionError):
+        serializer.serialize(BytesIO(), profile_uri=PROFILE_URI, max_depth=0)
+
+
+def test_output_is_valid_xml() -> None:
+    g, _ = _make_graph()
+    data = _serialize(g)
+    ET.fromstring(data)  # raises if not valid XML
+
+
+def test_full_model_child_elements() -> None:
+    g, _ = _make_graph()
+    data = _serialize(
+        g,
+        scenarioTime="2026-04-15T00:00:00Z",
+        created="2026-04-15T00:00:00Z",
+        description="Test model",
+        version="001",
+        modelingAuthoritySet="https://www.elvia.no",
+        applicationSoftware="cimfo/1.0.0",
+    )
+    assert b"Model.scenarioTime" in data
+    assert b"Model.created" in data
+    assert b"Model.description" in data
+    assert b"Model.version" in data
+    assert b"Model.profile" in data
+    assert b"Model.modelingAuthoritySet" in data
+    assert b"Model.applicationSoftware" in data
+    assert PROFILE_URI.encode() in data
+    assert b"cimfo/1.0.0" in data
+    assert b"https://www.elvia.no" in data
+
+
+def test_dependent_on_emitted_when_provided() -> None:
+    g, _ = _make_graph()
+    dep_uri = "urn:uuid:eq-model-abc123"
+    data = _serialize(g, dependent_on_eq=dep_uri)
+    assert b"DependentOn" in data
+    assert dep_uri.encode() in data
+
+
+def test_dependent_on_absent_when_not_provided() -> None:
+    g, _ = _make_graph()
+    data = _serialize(g)
+    assert b"DependentOn" not in data
+
+
+def test_cim_xml_registered_as_format() -> None:
+    """Graph.serialize(format='cim-xml') should resolve CIMXMLSerializer.
+
+    It requires profile_uri, so it raises ValueError (not a plugin lookup error).
+    """
+    g, _ = _make_graph()
+    with pytest.raises(ValueError, match="profile_uri"):
+        g.serialize(destination=BytesIO(), format="cim-xml")
+
+
+def test_subject_typed_element_present() -> None:
+    g, _ = _make_graph()
+    data = _serialize(g)
+    assert b"ACLineSegment" in data


### PR DESCRIPTION
## Summary

- Update pytest constraint from `<9.0.0` to `<10.0.0` in tests group so the fork's tests can run under pytest 9.x (needed for cimfo PR #236 which upgrades pytest to 9.0.3)
- Remove leftover AI-generation comment in `cimxml.py`
- Add 8 tests for `CIMXMLSerializer` (previously 0 bytes)

## Tests added

All FullModel child elements including `Model.applicationSoftware`, `Model.DependentOn` presence/absence, format registration, typed subject serialization, and error cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)